### PR TITLE
2947 add blog page and header

### DIFF
--- a/pages/blog-post/code-setup.htm
+++ b/pages/blog-post/code-setup.htm
@@ -1,0 +1,1 @@
+{% global active_page = 'blog' %}

--- a/pages/blog-post/page-blog-post.htm
+++ b/pages/blog-post/page-blog-post.htm
@@ -1,0 +1,27 @@
+---
+action: 'cmscontent:blog'
+template: inner
+protocol: all
+published: true
+name: 'Blog Post'
+url: /blog/:slug
+---
+<div class="row">
+    <!-- BLOG -->
+    {% if featured_image %}
+        <img src="{{ featured_image.thumbnail(1000, 'auto')|default('http://placehold.it/1000x365') }}" width="1000" alt="{{ featured_image.alt }}"/>
+    {% endif %}
+    <em class="twelve columns">In {{ post.type }} | {{ post.published_on | date("F j, Y") }}</em> 
+    {{ post.body | unescape }}
+    <!-- BIO -->
+	<div class="bio-container">
+	    {% if profile_image %}
+	        <img class="img-circle" src="{{ profile_image.thumbnail(252, 'auto')|default('http://placehold.it/100x100') }}" style="height: 100px; width: 100px;" alt="{{ profile_image.alt }}"/>
+	    {% endif %}
+	    <strong>{{ post.author_name }}</strong>
+	    {{ post.user.getSocialLinks()|unescape }}
+		<div class="author-bio">
+	        {{ post.user.user_bio|unescape }}
+		</div>
+	</div>
+</div>

--- a/pages/blog-post/page-blog-post.htm
+++ b/pages/blog-post/page-blog-post.htm
@@ -6,7 +6,7 @@ published: true
 name: 'Blog Post'
 url: /blog/:slug
 ---
-<div class="row">
+<div class="row blog-posts">
     <!-- BLOG -->
     {% if featured_image %}
         <img src="{{ featured_image.thumbnail(1000, 'auto')|default('http://placehold.it/1000x365') }}" width="1000" alt="{{ featured_image.alt }}"/>

--- a/pages/blog-post/page-blog-post.htm
+++ b/pages/blog-post/page-blog-post.htm
@@ -1,6 +1,6 @@
 ---
 action: 'cmscontent:blog'
-template: inner
+template: default
 protocol: all
 published: true
 name: 'Blog Post'

--- a/pages/blog-rss-feed/page-blog-rss-feed.htm
+++ b/pages/blog-rss-feed/page-blog-rss-feed.htm
@@ -1,0 +1,25 @@
+---
+action: 'cmscontent:feed'
+template: rss-2-0-feed
+protocol: all
+published: true
+name: 'Blog RSS feed'
+url: /blog/feed.xml
+---
+<channel>
+    <title>{{ page.title }}</title>
+    <link>{{ page.url }}</link>
+    <description><![CDATA[{{ page.description | unescape }} ]]></description>
+    <category domain="www.dmoz.com">{{ page.keywords }}</category>
+    <lastBuildDate>{{ published_on | date("r") }}</lastBuildDate>
+    <pubDate>{{ published_on | date("r") }}</pubDate>
+    <generator>LemonStand V2</generator>
+{% for post in feed %}
+  <item>
+    <title>{{ post.title }}</title>
+    <link>/blog/{{ post.guid }}</link>
+    <description><![CDATA[ {{ post.excerpt | unescape }} ]]></description>
+    <pubDate>{{ post.published_on | date("r") }}</pubDate>
+  </item>
+{% endfor %}
+</channel>

--- a/pages/blog/code-setup.htm
+++ b/pages/blog/code-setup.htm
@@ -1,0 +1,1 @@
+{% global active_page = 'blog' %}

--- a/pages/blog/page-blog.htm
+++ b/pages/blog/page-blog.htm
@@ -1,6 +1,6 @@
 ---
 action: 'cmscontent:archive'
-template: inner
+template: default
 protocol: all
 published: true
 name: Blog
@@ -13,7 +13,7 @@ url: /blog
             {% if post.status == "published" %}
                 {% set publishedPosts = publishedPosts + 1 %}
             {% endif %}
-            <div>
+            <div class="blog-posts">
                 <h2><a href="blog/{{ post.guid }}">{{ post.title }}</a></h2>
                 <div>{{ post.excerpt | unescape }}</div>
                 <div><a href="blog/{{ post.guid }}">Read More</a></div>
@@ -22,7 +22,7 @@ url: /blog
         {% endfor %}
     
         {% if archives | length == 0 or publishedPosts == 0 %}
-            <h2>No posts found</h2>
+            <h2 class="blog posts">No posts found</h2>
         {% endif %}
     </div>
 </div>

--- a/pages/blog/page-blog.htm
+++ b/pages/blog/page-blog.htm
@@ -1,0 +1,28 @@
+---
+action: 'cmscontent:archive'
+template: inner
+protocol: all
+published: true
+name: Blog
+url: /blog
+---
+<div class="row">
+    <div class="content twelve columns">
+        {% set publishedPosts = 0 %}
+        {% for post in archives %}
+            {% if post.status == "published" %}
+                {% set publishedPosts = publishedPosts + 1 %}
+            {% endif %}
+            <div>
+                <h2><a href="blog/{{ post.guid }}">{{ post.title }}</a></h2>
+                <div>{{ post.excerpt | unescape }}</div>
+                <div><a href="blog/{{ post.guid }}">Read More</a></div>
+            </div>
+            <hr/>
+        {% endfor %}
+    
+        {% if archives | length == 0 or publishedPosts == 0 %}
+            <h2>No posts found</h2>
+        {% endif %}
+    </div>
+</div>

--- a/pages/blog/page-blog.htm
+++ b/pages/blog/page-blog.htm
@@ -22,7 +22,9 @@ url: /blog
         {% endfor %}
     
         {% if archives | length == 0 or publishedPosts == 0 %}
-            <h2 class="blog posts">No posts found</h2>
+            <div class="blog-posts">
+                <h2>No posts found</h2>
+            </div>
         {% endif %}
     </div>
 </div>

--- a/partials/layout-header.htm
+++ b/partials/layout-header.htm
@@ -62,7 +62,7 @@
           </li>
 
           <li class="dropdown yamm-fw">
-            <a href="/blog" class="dropdown-toggle" data-toggle="dropdown">Blog</a>
+            <a href="/blog" class="dropdown-toggle">Blog</a>
           </li>
 
 

--- a/partials/layout-header.htm
+++ b/partials/layout-header.htm
@@ -61,6 +61,21 @@
             </ul>
           </li>
 
+          <li class="dropdown yamm-fw">
+            <a href="/blog" class="dropdown-toggle" data-toggle="dropdown">Blog</a>
+          </li>
+
+
+        <li class="dropdown yamm-fw">
+          <ul class="dropdown-menu shop-drop default-drop">
+            <div class="container yamm-content">
+              <ul class="cat-box">
+                <li><a href="/blog">Blog</a></li>
+              </ul>
+            </div>
+          </ul>
+        </li>
+
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li class="dropdown yamm-fw login-drop">

--- a/resources/stylesheets/custom.css
+++ b/resources/stylesheets/custom.css
@@ -3,3 +3,7 @@
   Write your custom CSS Styles Here
   
 =============================================*/
+
+.blog-posts {
+	margin-left: 25px;
+}

--- a/templates/rss-2-0-feed.htm
+++ b/templates/rss-2-0-feed.htm
@@ -1,0 +1,8 @@
+---
+content_type: 'text/plain; charset=utf-8'
+description: 'XML RSS feed'
+---
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+{{ page() }}
+</rss>


### PR DESCRIPTION
https://github.com/lemonstand/lemonstand-2/issues/2947

Testing checklist: 
- [x] Able to access blogs from home page (blog button in header)
- [x] Able to add a blog post from the backend 
- [x] blog post not cut off on left side of page
- [x] Readable error when there are no blog posts
